### PR TITLE
application/json should be default header always.

### DIFF
--- a/lib/att_speech/att_speech.rb
+++ b/lib/att_speech/att_speech.rb
@@ -47,12 +47,7 @@ class ATTSpeech
     @access_token  = ''
     @refresh_token = ''
 
-    if @scope == 'SPEECH'
-      create_connection 'application/json'
-    else
-      create_connection 'audio/x-wav'
-    end
-
+    create_connection
     get_tokens
 
     Actor.current

--- a/lib/att_speech/att_speech.rb
+++ b/lib/att_speech/att_speech.rb
@@ -2,7 +2,7 @@ class ATTSpeech
   include Celluloid
   Celluloid.logger = nil
 
-  attr_reader :api_key, :secret_key, :access_token, :refresh_token, :base_url, :ssl_verify, :scope
+  attr_reader :api_key, :secret_key, :access_token, :refresh_token, :base_url, :ssl_verify, :scope, :timeout
 
   ##
   # Creates an ATTSpeech object
@@ -14,12 +14,14 @@ class ATTSpeech
   #   @option args [String] :scope the Authorization Scope for the AT&T Speech API
   #   @option args [String] :base_url the url for the AT&T Speech API, default is 'https://api.att.com'
   #   @option args [Boolean] :ssl_verify determines if the peer Cert is verified for SSL, default is true
-  # @overload initialize(api_key, secret_key, base_url='https://api.att.com')
+  #   @option args [Integer] :timeout timeout for http request in seconds, by default set to 60
+  # @overload initialize(api_key, secret_key, scope, base_url='https://api.att.com', ssl_verify = true, timeout = 60)
   #   @param [String] api_key the AT&T Speech API Key
   #   @param [String] secret_key the AT&T Speech API Secret Key
   #   @param [String] scope the Authorization Scope for the AT&T Speech API
   #   @param [String] base_url the url for the AT&T Speech API, default is 'https://api.att.com'
   #   @param [Boolean] ssl_verify determines if the peer Cert is verified for SSL, default is true
+  #   @param [Integer] timeout timeout for http request in seconds, by default set to 60
   #
   # @return [Object] an instance of ATTSpeech
   def initialize(*args)
@@ -31,14 +33,16 @@ class ATTSpeech
       @api_key    = args[0][:api_key]
       @secret_key = args[0][:secret_key]
       @scope      = args[0][:scope]
-      @base_url   = args[0][:base_url]   || base_url
+      @base_url   = args[0][:base_url] || base_url
       set_ssl_verify args[0][:ssl_verify]
+      @timeout    = args[0][:timeout] || 60
     else
       @api_key    = args[0]
       @secret_key = args[1]
       @scope      = args[2]
       @base_url   = args[3] || base_url
       set_ssl_verify args[4]
+      @timeout    = args[5] || 60
     end
 
     raise ArgumentError, "scope must be either 'SPEECH' or 'TTS'" unless (@scope == 'SPEECH') || (@scope == 'TTS')
@@ -117,6 +121,7 @@ class ATTSpeech
     @connection = Faraday.new(:url => @base_url, :ssl => { :verify => @ssl_verify }) do |faraday|
       faraday.headers['Accept'] = accept_type
       faraday.adapter           Faraday.default_adapter
+      faraday.options[:timeout] = @timeout
     end
   end
 


### PR DESCRIPTION
Currently when you use TTS scope be feault 'Accept' header is set to 'audio/x-wav' which is wrong, default should be generic 'application/json'. More specific headers should be set in concrete method and override default one. Otherwise it  ay be a problem with OAuth token method because it accept only generic header.
